### PR TITLE
Added NEW_OPENIMIS_HOST as server_name to openimis.conf

### DIFF
--- a/conf/openimis.conf
+++ b/conf/openimis.conf
@@ -10,7 +10,7 @@ upstream docker-frontend {
 lua_shared_dict sessions 10m;     
 server {
         listen 80 default_server;
-        server_name _;
+        server_name NEW_OPENIMIS_HOST;
         return 301 https://$host$request_uri;
 }
 server {


### PR DESCRIPTION
Without this change, frontend was returning 502 Bad Gateway. 