### PR TITLE
Safety fixes and setup letsencrypt certificate

### DIFF
--- a/script/add-user.sh
+++ b/script/add-user.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 if [ "$#" -ne 2 ]
 then
   echo "Usage: $0 <USER_NAME> <USER_PASSWORD>" >&2
   exit 1
 fi
 echo -n "$1:" >> /conf/.htpasswd
-openssl passwd $2 >> /conf/.htpasswd
+openssl passwd "$2" >> /conf/.htpasswd

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -3,8 +3,12 @@ set -e
 rm -f /etc/nginx/conf.d/openIMIS.conf
 rm -f /etc/nginx/conf.d/default.conf
 cp  /script/default.conf /etc/nginx/conf.d/openIMIS.conf
-echo "Hosting on https://"$NEW_OPENIMIS_HOST
-sed -i 's|NEW_OPENIMIS_HOST|'$NEW_OPENIMIS_HOST'|g' /etc/nginx/conf.d/openIMIS.conf
-echo "Pointing to legacy openIMIS on https://"$LEGACY_OPENIMIS_HOST
-sed -i  's|LEGACY_OPENIMIS_HOST|'$LEGACY_OPENIMIS_HOST'|g' /etc/nginx/conf.d/openIMIS.conf
+echo "Hosting on https://""$NEW_OPENIMIS_HOST"
+sed -i 's|NEW_OPENIMIS_HOST|'"$NEW_OPENIMIS_HOST"'|g' /etc/nginx/conf.d/openIMIS.conf
+echo "Pointing to legacy openIMIS on https://""$LEGACY_OPENIMIS_HOST"
+sed -i 's|LEGACY_OPENIMIS_HOST|'"$LEGACY_OPENIMIS_HOST"'|g' /etc/nginx/conf.d/openIMIS.conf
+if [ -e "/etc/letsencrypt/live/$NEW_OPENIMIS_HOST/fullchain.pem" ]; then
+  sed -i  "s/\/etc\/ssl\/certs\/localhost\.crt/\/etc\/letsencrypt\/live\/$NEW_OPENIMIS_HOST\/fullchain\.pem/g" /etc/nginx/conf.d/openIMIS.conf
+  sed -i  "s/\/etc\/ssl\/private\/localhost\.key/\/etc\/letsencrypt\/live\/$NEW_OPENIMIS_HOST\/privkey\.pem/g" /etc/nginx/conf.d/openIMIS.conf
+fi
 exec "$@"

--- a/script/install-certificate.sh
+++ b/script/install-certificate.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-certbot certonly --webroot -w /var/www/html -d $NEW_OPENIMIS_HOST
-sed -i  's/\/etc\/ssl\/certs\/localhost\.crt/\/etc\/letsencrypt\/live\/'$NEW_OPENIMIS_HOST'\/fullchain\.pem/g' /etc/nginx/conf.d/default.conf
-sed -i  's/\/etc\/ssl\/private\/localhost\.key/\/etc\/letsencrypt\/live\/'$NEW_OPENIMIS_HOST'\/privkey\.pem/g' /etc/nginx/conf.d/default.conf
+certbot certonly --webroot -w /var/www/html -d NEW_OPENIMIS_HOST
+sed -i  "s/\/etc\/ssl\/certs\/localhost\.crt/\/etc\/letsencrypt\/live\/$NEW_OPENIMIS_HOST\/fullchain\.pem/g" /etc/nginx/conf.d/openIMIS.conf
+sed -i  "s/\/etc\/ssl\/private\/localhost\.key/\/etc\/letsencrypt\/live\/$NEW_OPENIMIS_HOST\/privkey\.pem/g" /etc/nginx/conf.d/openIMIS.conf
 openresty -s reload

--- a/script/renew-certificate.sh
+++ b/script/renew-certificate.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-echo "`date` Check certificate" >> /var/log/certbot
+echo "$(date) Check certificate" >> /var/log/certbot
 certbot renew --post-hook "openresty -s reload"

--- a/script/update-user.sh
+++ b/script/update-user.sh
@@ -5,5 +5,5 @@ then
   exit 1
 fi
 BASEDIR=$(dirname "$0")
-sh ${BASEDIR}/remove-user.sh $1
-sh ${BASEDIR}/add-user.sh $1 $2
+sh "${BASEDIR}"/remove-user.sh "$1"
+sh "${BASEDIR}"/add-user.sh "$1" "$2"


### PR DESCRIPTION
Several bash safety fixes (not really a problem in this context)
The script for let's encrypt used the wrong config file (default.conf instead of openIMIS.conf) and was therefore ignored.

Additonally, the entrypoint was copying the default.conf to openIMIS.conf again, replacing some parameters which overwrote the result of the letsencrypt installation.
I updated the entrypoint to also adapt the letsencrypt certificates if they are present.