### PR TITLE
OE0-103: Added X-Forwarded-Proto header to /api/ proxy

### DIFF
--- a/conf/openimis.conf
+++ b/conf/openimis.conf
@@ -49,6 +49,7 @@ server {
                 proxy_set_header   X-Real-IP $remote_addr;
                 proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header   X-Forwarded-Host $server_name;
+                proxy_set_header   X-Forwarded-Proto https;
                 proxy_set_header   remote-user $remote_user;
         }
 }

--- a/conf/openimis_win.conf
+++ b/conf/openimis_win.conf
@@ -105,6 +105,7 @@ server {
                 proxy_set_header   X-Real-IP $remote_addr;
                 proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header   X-Forwarded-Host $server_name;
+                proxy_set_header   X-Forwarded-Proto https;
                 proxy_set_header   remote-user $remote_user;
         }
 }


### PR DESCRIPTION
Required by the Django backend to properly build query urls.
TICKE: [OE0-103](https://openimis.atlassian.net/browse/OE0-103)